### PR TITLE
Add method to expose `Decimal` type

### DIFF
--- a/src/amount/expression.rs
+++ b/src/amount/expression.rs
@@ -153,6 +153,14 @@ impl Value {
     pub fn try_into_f32(self) -> Result<f32, ConversionError> {
         self.try_into()
     }
+    /// Retrieve the internal `Decimal` value.
+    /// This cannot error, since this type is based off of `Decimal`.
+    /// This is mostly useful for higher-level libraries to continue doing math with the values
+    /// created here.
+    pub fn get_decimal(&self) -> Decimal {
+        let Self(v) = self;
+        *v
+    }
 }
 
 impl TryFrom<Value> for f64 {

--- a/src/amount/expression.rs
+++ b/src/amount/expression.rs
@@ -157,6 +157,7 @@ impl Value {
     /// This cannot error, since this type is based off of `Decimal`.
     /// This is mostly useful for higher-level libraries to continue doing math with the values
     /// created here.
+    #[must_use]
     pub fn get_decimal(&self) -> Decimal {
         let Self(v) = self;
         *v


### PR DESCRIPTION
Since financial transactions cannot reliably be done with floats, there should be a way to get the Decimal type being stored as the `Value` type. There should be some way to expose the underlying type, reexport it, or something of the like.

For example, if I want to verify that all postings in a transaction balance to zero, then I have to cast this value to an `f32` or `f64` which looses precision and causes weird IEEE floating-point math problems.

```rust
let sum = postings.iter()
    .map(|p| p.amount().unwrap().expression().evaluate().try_into_f64().unwrap())
    .sum();
```

This will often result in postings that are `+/-0.0000000002394838333`; there should be a way to use the Decimal type directly so that maths may be done with it external to your library.