### PR TITLE
Make accounts hashable for faster lookups

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -19,14 +19,14 @@ use nom::{
 ///
 /// * `Assets:Liquidity:Cash` (type: `Assets`, components: ["Liquidity", "Cash"]
 /// * `Expenses:Groceries` (type: `Assets`, components: ["Groceries"]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Account<'a> {
     type_: Type,
     components: Vec<&'a str>,
 }
 
 /// Type of account
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Type {
     /// The assets
     Assets,


### PR DESCRIPTION
For higher-level crates, listing every account could be a loop of a few hundred on every single posting to verify the openness of an account.

Right now, verification of a transaction is `O(m*(n+o))`, where m is the number of postings, n in the number of open directives, and o is the number of close directives.
This will bring it down to `O(m)`, since now, finding the open/close directive associated with an account should be `O(1)`.