### PR TITLE
fix: failure to parse terminal decimal points

### DIFF
--- a/src/amount/expression.rs
+++ b/src/amount/expression.rs
@@ -238,7 +238,8 @@ fn value(input: &str) -> IResult<&str, Value> {
     let value_string = recognize(tuple((
         opt(char('-')),
         digit0,
-        opt(preceded(char('.'), digit1)),
+        opt(char('.')),
+        opt(digit1),
     )));
     map(map_res(value_string, str::parse), Value)(input)
 }
@@ -250,8 +251,10 @@ mod tests {
     #[rstest]
     #[case("0", Decimal::ZERO)]
     #[case("42", Decimal::new(42, 0))]
+    #[case("42.", Decimal::new(42, 0))]
     #[case("1.1", Decimal::new(11, 1))]
     #[case(".1", Decimal::new(1, 1))]
+    #[case("-.1", -Decimal::new(1, 1))]
     #[case("-2", -Decimal::new(2, 0))]
     fn parse_value(#[case] input: &str, #[case] expected: Decimal) {
         assert_eq!(parse(input), Ok(("", Expression::Value(Value(expected)))));

--- a/src/amount/expression.rs
+++ b/src/amount/expression.rs
@@ -235,12 +235,7 @@ fn exp_p2(input: &str) -> IResult<&str, Expression> {
 }
 
 fn value(input: &str) -> IResult<&str, Value> {
-    let value_string = recognize(tuple((
-        opt(char('-')),
-        digit0,
-        opt(char('.')),
-        opt(digit1),
-    )));
+    let value_string = recognize(tuple((opt(char('-')), digit0, opt(char('.')), opt(digit1))));
     map(map_res(value_string, str::parse), Value)(input)
 }
 

--- a/src/amount/expression.rs
+++ b/src/amount/expression.rs
@@ -3,7 +3,7 @@ use nom::{
     character::complete::{char, digit0, digit1, space0},
     combinator::{map, map_res, opt, recognize},
     multi::many0,
-    sequence::{delimited, preceded, tuple},
+    sequence::{delimited, tuple},
     IResult,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal};


### PR DESCRIPTION
Hi, thank you for publishing this great repo! I enjoyed using it on my own beancount files. I noticed a crash which this should fix. 😄 

Previously, an amount such as `10.` would cause the parser to crash. This change fixes that parsing error, which is allowed in beacnount syntax.