### PR TITLE
fix: failure to parse currencies with numbers or special chars

### DIFF
--- a/src/amount.rs
+++ b/src/amount.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[rstest]
-    fn valid_currency(#[values("CHF", "X-A", "A", "AB")] input: &str) {
+    fn valid_currency(#[values("CHF", "X-A", "X_A", "X'A", "A", "AB", "A2", "R2D2")] input: &str) {
         assert_eq!(all_consuming(currency)(input), Ok(("", input)));
     }
 

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -67,7 +67,7 @@ fn current_first_char(input: &str) -> IResult<&str, char> {
 fn current_middle_char(input: &str) -> IResult<&str, char> {
     alt((
         satisfy(|c: char| c.is_ascii_uppercase() && c.is_ascii_alphabetic()),
-        satisfy(|c: char| c.is_numeric()),
+        satisfy(char::is_numeric),
         one_of("'._-"),
     ))(input)
 }
@@ -75,7 +75,7 @@ fn current_middle_char(input: &str) -> IResult<&str, char> {
 fn current_last_char(input: &str) -> IResult<&str, char> {
     alt((
         satisfy(|c: char| c.is_ascii_uppercase() && c.is_ascii_alphabetic()),
-        satisfy(|c: char| c.is_numeric()),
+        satisfy(char::is_numeric),
     ))(input)
 }
 
@@ -125,6 +125,6 @@ mod tests {
     #[rstest]
     fn invalid_currency(#[values("CHF-", "X-a", "1A", "aA")] input: &str) {
         let p = all_consuming(currency)(input);
-        assert!(p.is_err(), "Result was actually: {:#?}", p);
+        assert!(p.is_err(), "Result was actually: {p:#?}");
     }
 }


### PR DESCRIPTION
The current currency parser fails to parse many valid situations. The correct definition is [defined here](https://beancount.github.io/docs/beancount_language_syntax.html#commodities-currencies) in the Beancount documentation. In particular, special characters are allowed in the middle of the string, and numbers are allowed at the end of the string.