### PR TITLE
feat: balance assertion directive

### DIFF
--- a/src/assertion.rs
+++ b/src/assertion.rs
@@ -1,0 +1,88 @@
+use crate::account::{account, Account};
+use crate::date::date;
+use crate::Date;
+use crate::{amount::amount, Amount};
+
+use nom::{
+    bytes::complete::tag,
+    character::streaming::space1,
+    combinator::map,
+    sequence::{terminated, tuple},
+    IResult,
+};
+
+/// Account balance assertion directive
+#[derive(Clone, Debug, PartialEq)]
+pub struct Assertion<'a> {
+    date: Date,
+    account: Account<'a>,
+    amount: Amount<'a>,
+}
+
+impl<'a> Assertion<'a> {
+    /// Date at which the assertion is calculated
+    #[must_use]
+    pub fn date(&self) -> Date {
+        self.date
+    }
+
+    /// Account to test
+    #[must_use]
+    pub fn account(&self) -> &Account<'a> {
+        &self.account
+    }
+
+    /// Expected balance amount
+    #[must_use]
+    pub fn amount(&self) -> &Amount<'a> {
+        &self.amount
+    }
+}
+
+pub(crate) fn assertion(input: &str) -> IResult<&str, Assertion<'_>> {
+    map(
+        tuple((
+            terminated(date, tuple((space1, tag("balance"), space1))),
+            terminated(account, space1),
+            amount,
+        )),
+        |(date, account, amount)| Assertion {
+            date,
+            account,
+            amount,
+        },
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use nom::combinator::all_consuming;
+
+    use crate::account::Type;
+
+    #[test]
+    fn valid_assertion() {
+        let input = "2014-01-01 balance Assets:Unknown 1 USD";
+        let r = all_consuming(assertion)(input);
+        assert_eq!(
+            r,
+            Ok((
+                "",
+                Assertion {
+                    date: Date::new(2014, 1, 1),
+                    account: Account::new(Type::Assets, ["Unknown"]),
+                    amount: Amount::new(1, "USD")
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_assertion() {
+        let input = "2014-01-01 balance";
+        let p = all_consuming(assertion)(input);
+        assert!(p.is_err());
+    }
+}

--- a/src/directive.rs
+++ b/src/directive.rs
@@ -1,7 +1,8 @@
+use crate::assertion::assertion;
 use crate::close::close;
 use crate::open::open;
 use crate::price::{price, Price};
-use crate::{Close, Date, Open};
+use crate::{Assertion, Close, Date, Open};
 use nom::branch::alt;
 use nom::{combinator::map, IResult};
 
@@ -23,6 +24,8 @@ pub enum Directive<'a> {
     Open(Open<'a>),
     /// The [`Close`](crate::Close) account directive
     Close(Close<'a>),
+    /// The [`Assertion`](crate::Assertion) (`balance`) account directive
+    Assertion(Assertion<'a>),
 }
 
 impl<'a> Directive<'a> {
@@ -56,6 +59,7 @@ impl<'a> Directive<'a> {
             Directive::Open(o) => o.date(),
             Directive::Close(c) => c.date(),
             Directive::Price(p) => p.date(),
+            Directive::Assertion(a) => a.date(),
         })
     }
 }
@@ -66,6 +70,7 @@ pub(crate) fn directive(input: &str) -> IResult<&str, Directive<'_>> {
         map(price, Directive::Price),
         map(open, Directive::Open),
         map(close, Directive::Close),
+        map(assertion, Directive::Assertion),
     ))(input)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ extern crate rstest;
 
 pub mod account;
 pub mod amount;
+mod assertion;
 mod close;
 mod date;
 mod directive;
@@ -64,8 +65,8 @@ pub mod transaction;
 use crate::directive::directive;
 
 pub use crate::{
-    account::Account, amount::Amount, close::Close, date::Date, directive::Directive, error::Error,
-    open::Open, price::Price, transaction::Transaction,
+    account::Account, amount::Amount, assertion::Assertion, close::Close, date::Date,
+    directive::Directive, error::Error, open::Open, price::Price, transaction::Transaction,
 };
 
 use nom::{

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -166,8 +166,6 @@ fn flag(input: &str) -> IResult<&str, Flag> {
 mod tests {
     use super::*;
 
-    use crate::account::{Account, Type};
-
     #[rstest]
     fn simple_transaction() {
         let input = r#"2022-09-16 * "Hello \"world\""

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -166,6 +166,8 @@ fn flag(input: &str) -> IResult<&str, Flag> {
 mod tests {
     use super::*;
 
+    use crate::account::{Account, Type};
+
     #[rstest]
     fn simple_transaction() {
         let input = r#"2022-09-16 * "Hello \"world\""


### PR DESCRIPTION
This change adds support for parsing `balance` assertions ([Beancount documentation](https://beancount.github.io/docs/beancount_language_syntax.html#balance-assertions)). They look like this:

```
2014-12-26 balance Liabilities:US:CreditCard   -3492.02 USD
```