### PR TITLE
allow commodities that end with numbers

### DIFF
--- a/src/amount.rs
+++ b/src/amount.rs
@@ -173,7 +173,12 @@ pub(crate) fn currency(input: Span<'_>) -> IResult<'_, Currency> {
             take_while(|c: char| {
                 c.is_uppercase() || c.is_numeric() || c == '-' || c == '_' || c == '.' || c == '\''
             }),
-            |s: &Span<'_>| s.fragment().chars().last().map_or(true, char::is_uppercase),
+            |s: &Span<'_>| {
+                s.fragment()
+                    .chars()
+                    .last()
+                    .map_or(true, |c| c.is_uppercase() || c.is_numeric())
+            },
         ),
     )))(input)?;
     Ok((input, Currency(Arc::from(*currency.fragment()))))

--- a/tests/parser_spec.rs
+++ b/tests/parser_spec.rs
@@ -240,6 +240,15 @@ fn should_parse_commodity() {
 }
 
 #[rstest]
+fn should_parse_commodity_that_ends_with_number() {
+    let input = "1792-01-01 commodity A1";
+    let DirectiveContent::Commodity(commodity) = parse_single_directive(input).content else {
+        panic!("was not an commodity directive");
+    };
+    assert_eq!(commodity.as_str(), "A1");
+}
+
+#[rstest]
 fn should_parse_event() {
     let input = "2020-12-09 event \"location\" \"New Metropolis\"";
     let DirectiveContent::Event(event) = parse_single_directive(input).content else {
@@ -377,7 +386,6 @@ fn should_reject_invalid_input(
         "2014-05-01 open Assets:Checking Hello",
         "2014-05-01 open Assets:Checking USD CHF",
         "2014-05-01 open Assets:Checking 1SD",
-        "2014-05-01 open Assets:Checking US2",
         "2014-05-01 open Assets:Checking US-",
         "2014-05-01 open Assets:Checking -US",
         "2014-05-01close Assets:Cash",


### PR DESCRIPTION
According to https://beancount.github.io/docs/beancount_language_syntax.html#commodities-currencies:

> Technically, a currency name may be up to 24 characters long, and it must start with a capital letter, must end with with a capital letter or **number**