### PR TITLE
Add `Display` impls for directive

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -109,6 +109,29 @@ impl Open {
     }
 }
 
+impl Display for Open {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "open {}", self.account)?;
+
+        let mut first = true;
+        for currency in &self.currencies {
+            if first {
+                write!(f, " ")?;
+                first = false;
+            } else {
+                write!(f, ",")?;
+            }
+            write!(f, "{currency}")?;
+        }
+
+        if let Some(booking_method) = &self.booking_method {
+            write!(f, " \"{booking_method}\"")?;
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BookingMethod(Arc<str>);
 
@@ -161,6 +184,12 @@ impl Close {
     }
 }
 
+impl Display for Close {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "close {}", self.account)
+    }
+}
+
 /// Balance assertion
 ///
 /// # Example
@@ -197,6 +226,20 @@ impl<D> Balance<D> {
     }
 }
 
+impl<D: Display> Display for Balance<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "balance {} {}", self.account, self.amount.value)?;
+
+        if let Some(tolerance) = &self.tolerance {
+            write!(f, " ~ {}", &tolerance)?;
+        }
+
+        write!(f, " {}", self.amount.currency)?;
+
+        Ok(())
+    }
+}
+
 /// Pad directive
 ///
 /// # Example
@@ -225,6 +268,12 @@ impl Pad {
             account,
             source_account,
         }
+    }
+}
+
+impl Display for Pad {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "pad {} {}", self.account, self.source_account)
     }
 }
 

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -38,6 +38,12 @@ pub struct Price<D> {
     pub amount: Amount<D>,
 }
 
+impl<D: Display> Display for Price<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "price {} {}", self.currency, self.amount)
+    }
+}
+
 /// Amount
 ///
 /// Where `D` is the decimal type (like `f64` or `rust_decimal::Decimal`)
@@ -49,6 +55,12 @@ pub struct Amount<D> {
     pub value: D,
     /// Currency
     pub currency: Currency,
+}
+
+impl<D: Display> Display for Amount<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.value, self.currency)
+    }
 }
 
 /// Currency

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, str::FromStr};
+use std::{cmp::Ordering, fmt::Display, str::FromStr};
 
 use nom::{
     bytes::complete::take,
@@ -35,6 +35,12 @@ pub struct Date {
     pub month: u8,
     /// Day (of month)
     pub day: u8,
+}
+
+impl Display for Date {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{:02}-{:02}", self.year, self.month, self.day)
+    }
 }
 
 impl Date {

--- a/src/event.rs
+++ b/src/event.rs
@@ -30,6 +30,12 @@ impl Event {
     }
 }
 
+impl std::fmt::Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "event \"{}\" \"{}\"", self.name, self.value)
+    }
+}
+
 pub(super) fn parse(input: Span<'_>) -> IResult<'_, Event> {
     let (input, name) = string(input)?;
     let (input, _) = space1(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 
 use std::{
     collections::HashSet,
+    fmt::{Debug, Display},
     fs::File,
     io::Read,
     path::{Path, PathBuf},
@@ -354,6 +355,20 @@ pub struct Directive<D> {
     pub line_number: u32,
 }
 
+impl<D: Display> Display for Directive<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.date, f)?;
+        f.write_str(" ")?;
+        Display::fmt(&self.content, f)?;
+
+        for (key, value) in &self.metadata {
+            write!(f, "\n  {key}: {value}")?;
+        }
+
+        Ok(())
+    }
+}
+
 impl<D: Decimal> FromStr for Directive<D> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -377,6 +392,21 @@ pub enum DirectiveContent<D> {
     Pad(Pad),
     Commodity(Currency),
     Event(Event),
+}
+
+impl<D: Display> Display for DirectiveContent<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DirectiveContent::Transaction(transaction) => Display::fmt(transaction, f),
+            DirectiveContent::Price(price) => Display::fmt(price, f),
+            DirectiveContent::Balance(balance) => Display::fmt(balance, f),
+            DirectiveContent::Open(open) => Display::fmt(open, f),
+            DirectiveContent::Close(close) => Display::fmt(close, f),
+            DirectiveContent::Pad(pad) => Display::fmt(pad, f),
+            DirectiveContent::Commodity(currency) => write!(f, "commodity {currency}"),
+            DirectiveContent::Event(event) => Display::fmt(event, f),
+        }
+    }
 }
 
 impl<D> DirectiveContent<D> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -112,6 +112,15 @@ impl<D> Value<D> {
         }
     }
 }
+impl<D: Display> Display for Value<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::String(value) => write!(f, r#""{value}""#),
+            Value::Number(value) => Display::fmt(value, f),
+            Value::Currency(value) => Display::fmt(value, f),
+        }
+    }
+}
 
 pub(crate) fn parse<D: Decimal>(input: Span<'_>) -> IResult<'_, Map<D>> {
     let mut iter = iterator(input, alt((entry.map(Some), empty_line.map(|()| None))));

--- a/tests/display_spec.rs
+++ b/tests/display_spec.rs
@@ -1,0 +1,109 @@
+#![allow(missing_docs)]
+
+use rstest::rstest;
+
+use beancount_parser::parse;
+
+#[rstest]
+#[case(r#"2020-01-01 ! "" "narration""#)]
+#[case(r#"2020-01-01 ! "payee" "narration""#)]
+#[case(r#"2020-01-01 ! "narration""#)]
+#[case(r#"2020-01-01 * "Store" "Groceries" #food ^receipt"#)]
+#[case(
+    r#"2020-01-01 * "" "Test"
+  Assets:Cash 100 USD
+  Income:Salary"#
+)]
+#[case("2023-01-01 price USD 0.92 EUR")]
+#[case("2020-01-01 balance Assets:Cash 123 EUR")]
+#[case("2020-01-01 balance Assets:Cash 123 ~ 0.1 EUR")]
+#[case("2020-01-01 open Assets:Cash USD")]
+// #[case("2020-01-01 open Assets:Cash USD,EUR")] disabled due to non-stable output
+#[case("2020-01-01 open Assets:Cash USD \"method\"")]
+#[case("2020-01-01 open Assets:Cash")]
+#[case("2023-12-31 close Assets:Cash")]
+#[case("2020-01-01 pad Assets:Cash Equity:Opening")]
+#[case("2020-01-01 commodity USD")]
+#[case("2020-01-01 event \"location\" \"home\"")]
+/*#[case(
+    r#"2020-01-01 close Assets:Cash
+  note: "Account closed"
+  count: 42
+  currency: USD"#
+)] disabled due to non-stable output*/
+#[case(
+    r#"2020-01-01 * "Store" "Groceries" #food ^receipt
+  Assets:Cash -50 USD
+  Expenses:Groceries 50 USD
+    category: "essentials""#
+)]
+fn display_roundtrip(#[case] input: &str) {
+    let parsed = parse::<f64>(input).unwrap_or_else(|_| panic!("Failed to parse:\n  {}", input));
+    let directive = &parsed.directives[0];
+    let displayed = directive.to_string();
+
+    assert_eq!(input, displayed, "Round-trip failed");
+}
+
+#[rstest]
+#[case(
+    // floats get normalized
+    "2020-01-01 balance Assets:Cash 100.50 USD",
+    "2020-01-01 balance Assets:Cash 100.5 USD"
+)]
+// transactions syntax is normalized
+#[case(r#"2020-01-01 txn "Narration""#, r#"2020-01-01 txn "Narration""#)]
+#[case(
+    r#"2020-01-01   balance    Assets:Cash  10  USD"#,
+    r#"2020-01-01 balance Assets:Cash 10 USD"#
+)]
+fn directive_display_changes(#[case] input: &str, #[case] expected: &str) {
+    let result = parse::<f64>(input).unwrap();
+    let directive = &result.directives[0];
+    assert_eq!(directive.to_string(), expected);
+}
+
+#[rstest]
+#[case(
+    r#"2020-01-01 * ""
+  Assets:Cash   100 USD"#,
+    "Assets:Cash 100 USD"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  Income:Salary"#,
+    "Income:Salary"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  ! Assets:Cash   100 USD"#,
+    "! Assets:Cash 100 USD"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  Assets:Cash   10 STOCK @ 50.00 USD"#,
+    "Assets:Cash 10 STOCK @ 50 USD"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  Assets:Cash   10 STOCK @@ 500.00 USD"#,
+    "Assets:Cash 10 STOCK @@ 500 USD"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  Assets:Cash   10 STOCK {50.00 USD}"#,
+    "Assets:Cash 10 STOCK {50 USD}"
+)]
+#[case(
+    r#"2020-01-01 * ""
+  Assets:Cash   10 STOCK {2022-01-01, 50.00 USD}"#,
+    "Assets:Cash 10 STOCK {2022-01-01, 50 USD}"
+)]
+fn posting_display(#[case] input: &str, #[case] expected: &str) {
+    let result = parse::<f64>(input).unwrap();
+    let directive = &result.directives[0];
+    let output = directive.to_string();
+    let lines: Vec<&str> = output.lines().collect();
+    let posting_line = lines[1].trim_start();
+    assert_eq!(posting_line, expected);
+}


### PR DESCRIPTION
Even if this library is not meant do modify beancount syntax in place, it's still useful to be able to print a directive in a readable way that corresponds to actual beancount code.

This PR, specifically https://github.com/jcornaz/beancount-parser/commit/d54defeb35feab8bbca5ec3b21476e81dfd67cc5, adds `Display` impls for `Directive` and its component types.

The impls aren't exactly syntax preserving, e.g. floats get normalized `50.0 -> 50`, spaces get removed etc.

Maybe there should also be a comment somewhere that these display impls aren't guaranteed to be stable across semver non-breaking versions.


builds on top of #113 for stable order