### PR TITLE
add iterator based `read_files_iter -> Iterator<Result<Directive>>` method

### DIFF
--- a/tests/parse_from_file_spec.rs
+++ b/tests/parse_from_file_spec.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use rstest::rstest;
 
-use beancount_parser::BeancountFile;
+use beancount_parser::{BeancountFile, Entry};
 
 #[rstest]
 #[case("comments.beancount", 0)]
@@ -24,4 +24,18 @@ fn can_parse_example_files(#[case] file_name: &str, #[case] expected_directive_c
         file.extend(beancount_parser::read_files_to_vec([path]).unwrap());
         assert_eq!(file.directives.len(), expected_directive_count);
     }
+}
+
+#[rstest]
+#[case("comments.beancount", 0)]
+#[case("simple.beancount", 16)]
+#[case("official.beancount", 1714 + 2)] // include entries are emitted as well
+#[case("includes.beancount", 1731 + 2)]
+fn can_parse_example_files_iter(#[case] file_name: &str, #[case] expected_directive_count: usize) {
+    let mut path: PathBuf = "./tests/samples".into();
+    path.push(file_name);
+    let directives = beancount_parser::read_files_iter([path])
+        .collect::<Result<Vec<Entry<f64>>, _>>()
+        .unwrap();
+    assert_eq!(directives.len(), expected_directive_count);
 }


### PR DESCRIPTION
It's often more convenient to work with an iterator, rather than a calllback function.
This PR adds `beancount_parser::read_files_iter`, which works like `read_files` except that it returns an iterator over all `Entry`s, recursively.

```rs
use beancount_parser::{read_files_iter, Entry};
use std::path::PathBuf;

let iter = read_files_iter::<f64>(std::iter::once(PathBuf::from("journal.beancount")));

for entry in iter {
    let entry = entry?;
    match entry {
        Entry::Directive(directive) => {
            println!("Found directive: {:?}", directive.content);
        }
        Entry::Option(option) => {
            println!("Found option: {} = {}", option.name, option.value);
        }
        Entry::Include(_) => unreachable!(),
        _ => {} // Entry is #[non_exhaustive]
    }
}
```

Do you have a preference for whether `Import` entries should be emitted as well?
I think I remember having a use case but I can't find it right now.

I lean towards yes, because that's less magic, preserves more information, and if you're only interested in Directives you're gonna have to pattern match either way.