### PR TITLE
add constructors

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -97,6 +97,18 @@ pub struct Open {
     pub booking_method: Option<BookingMethod>,
 }
 
+impl Open {
+    /// Create an open directive from an account
+    #[must_use]
+    pub fn from_account(account: Account) -> Self {
+        Open {
+            account,
+            currencies: HashSet::new(),
+            booking_method: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BookingMethod(Arc<str>);
 
@@ -141,6 +153,14 @@ pub struct Close {
     pub account: Account,
 }
 
+impl Close {
+    /// Create a close directive from an account
+    #[must_use]
+    pub fn from_account(account: Account) -> Self {
+        Close { account }
+    }
+}
+
 /// Balance assertion
 ///
 /// # Example
@@ -166,6 +186,17 @@ pub struct Balance<D> {
     pub tolerance: Option<D>,
 }
 
+impl<D> Balance<D> {
+    /// Create a new from account and amount, with unspecified tolerance
+    pub fn new(account: Account, amount: Amount<D>) -> Self {
+        Balance {
+            account,
+            amount,
+            tolerance: None,
+        }
+    }
+}
+
 /// Pad directive
 ///
 /// # Example
@@ -184,6 +215,17 @@ pub struct Pad {
     pub account: Account,
     /// Source account from which take the money
     pub source_account: Account,
+}
+
+impl Pad {
+    /// Create a new pad directive
+    #[must_use]
+    pub fn new(account: Account, source_account: Account) -> Self {
+        Pad {
+            account,
+            source_account,
+        }
+    }
 }
 
 pub(super) fn parse(input: Span<'_>) -> IResult<'_, Account> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -22,6 +22,14 @@ pub struct Event {
     pub value: String,
 }
 
+impl Event {
+    /// Create a new event
+    #[must_use]
+    pub fn new(name: String, value: String) -> Event {
+        Event { name, value }
+    }
+}
+
 pub(super) fn parse(input: Span<'_>) -> IResult<'_, Event> {
     let (input, name) = string(input)?;
     let (input, _) = space1(input)?;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -42,7 +42,7 @@ use crate::{
 /// assert!(trx.tags.contains("food"));
 /// assert_eq!(trx.postings.len(), 2);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub struct Transaction<D> {
     /// Transaction flag (`*` or `!` or `None` when using the `txn` keyword)
@@ -101,6 +101,21 @@ pub struct Posting<D> {
     pub price: Option<PostingPrice<D>>,
     /// The metadata attached to the posting
     pub metadata: metadata::Map<D>,
+}
+
+impl<D> Posting<D> {
+    /// Create a new empty posting for the given account
+    #[must_use]
+    pub fn from_account(account: Account) -> Posting<D> {
+        Posting {
+            flag: None,
+            account,
+            amount: None,
+            cost: None,
+            price: None,
+            metadata: metadata::Map::new(),
+        }
+    }
 }
 
 /// Cost of a posting


### PR DESCRIPTION
While working on https://github.com/jakobhellermann/beancount-staging I needed a way to create a new transaction with postings.
Due to the `non_exhaustive` attributes this currently isn't possible.

By adding a constructor I can create a new posting and modify the public fields afterwards.

Let me know if you would want a different interface, like passing all fields in the constructor, or having `::new` method for everything else as well.