### PR TITLE
Add path to io error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -68,14 +68,23 @@ impl Error {
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "miette", derive(Diagnostic))]
 pub enum ReadFileError {
-    #[error("IO error in {path}: {source}")]
-    Io {
-        path: std::path::PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
+    #[error("{0}")]
+    Io(#[source] ReadFileIOError),
     #[error("Syntax error")]
     Syntax(#[from] Error),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub struct ReadFileIOError {
+    pub path: std::path::PathBuf,
+    pub cause: std::io::Error,
+}
+
+impl std::fmt::Display for ReadFileIOError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IO error in {}: {}", self.path.display(), self.cause)
+    }
 }
 
 /// Error that may be returned by the various `TryFrom`/`TryInto` implementation


### PR DESCRIPTION
The io entrypoints like `fn read_files` take a filename as input, but errors may be from any file internally after resolving includes.

It's annoying to get `IO Error: File does not exist` without knowing _which_ file doesn't exist.

This is a breaking change, so it would have to be batched with other breaking changes into 3.0.

based on #115 but I can rebase onto main instead